### PR TITLE
Use modified magento fulltext search for specific magento versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+* 0.2.0.0 (2017-08-16)
+  * added possibility to have multiple magazines per store view
+  * added sku parameter restriction for product details endpoint
+  * added category ids and description to product details endpoint
+  * added new version endpoint
+
 * 0.1.1.12 (2017-05-02)
   * pricing data for configurable products
   * support for [custom search engines](doc/customization/custom-search-engines.md)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Styla Connect (v 0.1.1.12)
+# Styla Connect (v 0.2.0.0)
 ---
 
 Requires:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -15,7 +15,7 @@ The assistant will use your Styla credentials to retrieve all the needed configu
 
 Once the connect process is done you will be able to change the below values for each store view/magazine.
 
-Styla plugin version 0.2.0.0 introduced a possibility to set up several magazines for the same store view. That’s why Styla plugin settings are now separated into two Magento menus:
+Styla plugin version [0.2.0.0](https://github.com/styladev/magentoStylaConnect/releases/tag/v0.2.0.0) introduced a possibility to set up several magazines for the same store view. That’s why Styla plugin settings are now separated into two Magento menus:
 
 ### System > Configuration > Styla Connect (for all magazines):
 
@@ -146,7 +146,7 @@ footer
 
 /* - Please do not modify these values. This configuration will be automatically set during the “Styla Connect” process from the previous step.
 
-For Styla plugin version 0.1.1.12 and earlier all the settings above are available in **System > Configuration > Styla Connect**  as there is only one magazine available per store view. 
+For Styla plugin version [0.1.1.12](https://github.com/styladev/magentoStylaConnect/releases/tag/v0.1.1.12) and earlier all the settings above are available in **System > Configuration > Styla Connect**  as there is only one magazine available per store view. 
 
 
 ## StylaApiAdminUser and StylaApi2Role - please don't modify

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -15,15 +15,52 @@ The assistant will use your Styla credentials to retrieve all the needed configu
 
 Once the connect process is done you will be able to change the below values for each store view/magazine.
 
+Styla plugin version 0.2.0.0 introduced a possibility to set up several magazines for the same store view. That’s why Styla plugin settings are now separated into two Magento menus:
+
+### System > Configuration > Styla Connect (for all magazines):
+
 <table>
 <tr>
-<th>Name</th>
+<th>Name (pre-0.2.0.0)</th>
 <th>Description</th>
 <th>Default</th>
 </tr>
 
 <tr>
-<td>Mode</td>
+<td>Use Relative Product Urls</td>
+<td>Defines how product URLs for magazine front-end will be created:
+
+<ul>
+<li>yes - the product urls generated for the stories will be relative to store domain (ie: /product-name-SKU/)
+</li>
+<li>no - no - full urls will be generated (ie: http://www.yourdomain.com/product-name-SKU/)
+</li>
+</ul>
+
+</td>
+<td>no</td>
+</tr>
+
+<tr>
+<td>Manufacturer Attribute</td>
+<td>Magento field that will be used to display manufacturer name</td>
+<td>Manufacturer</td>
+</tr>
+
+<tr>
+<td>Cache Lifetime</td>
+<td>The seo data cache lifetime</td>
+<td>3600</td>
+</tr>
+
+<tr>
+<td>Maximum Levels of Categories Loaded at Once</td>
+<td>If you run a store with a category tree consisting of multiple levels, you may choose to limit the number of the branches loaded into styla backoffice editor at once, for performance reasons)</td>
+<td>No limit - load all categories in a single API call</td>
+</tr>
+
+<tr>
+<td>Is Developer Mode (Mode)</td>
 <td>The Styla Connect endpoint:
 
 <ul>
@@ -39,22 +76,40 @@ Once the connect process is done you will be able to change the below values for
 <td>Production</td>
 </tr>
 
+</table>
+
+
+### CMS > Styla Magazines (for each magazine separately):
+
+<table>
 <tr>
-<td>Enabled</td>
-<td>Allows to enable or disable the magazine</td>
-<td>enabled</td>
+<th>Name (pre-0.2.0.0)</th>
+<th>Description</th>
+<th>Default</th>
 </tr>
 
 <tr>
-<td>Magazine frontend “Url”</td>
-<td>The url where the magazine is available</td>
-<td>/magazin</td>
+<td>Store name</td>
+<td>Defines on which store view will your magazine be displayed</td>
+<td>default store in your Magento</td>
+</tr>
+
+<tr>
+<td>Active (Enabled)</td>
+<td>Allows to enable or disable the magazine</td>
+<td>enabled</td>
 </tr>
 
 <tr>
 <td>Client Name*</td>
 <td>Name of the styla client (this could be different from the username)</td>
 <td></td>
+</tr>
+
+<tr>
+<td>Front Name (Magazine frontend “Url”)</td>
+<td>The part of the URL after your store view part where the magazine is available</td>
+<td>/magazin</td>
 </tr>
 
 <tr>
@@ -76,40 +131,13 @@ footer
 </tr>
 
 <tr>
-<td>Use Relative Product Urls</td>
-<td>Defines how product URLs for magazine front-end will be created:
-
-<ul>
-<li>yes - the product urls generated for the stories will be relative to store domain (ie: /product-name-SKU/)
-</li>
-<li>no - no - full urls will be generated (ie: http://www.yourdomain.com/product-name-SKU/)
-</li>
-</ul>
-
-</td>
-<td>no</td>
-</tr>
-
-<tr>
-<td>Cache Lifetime</td>
-<td>The seo data cache lifetime</td>
-<td>3600</td>
-</tr>
-
-<tr>
-<td>Maximum Levels of Categories Loaded at Once</td>
-<td>If you run a store with a category tree consisting of multiple levels, you may choose to limit the number of the branches loaded into styla backoffice editor at once, for performance reasons)</td>
-<td>No limit - load all categories in a single API call</td>
-</tr>
-
-<tr>
-<td>Add Magazine Link to Navigation</td>
+<td>Include in navigation (Add Magazine Link to Navigation)</td>
 <td>Turn to "No" if you don't want the magazine link to be available in the menu (good for testing the magazine before disclosing to your audience)</td>
 <td>Yes</td>
 </tr>
 
 <tr>
-<td>Label for the Magazine Menu Link</td>
+<td>Navigation label (Label for the Magazine Menu Link)</td>
 <td>Enter any name your audience see on the menu linking to the magazine</td>
 <td>Magazine</td>
 </tr>
@@ -117,6 +145,11 @@ footer
 </table>
 
 /* - Please do not modify these values. This configuration will be automatically set during the “Styla Connect” process from the previous step.
+
+You can also add new magazines there.
+
+For Styla plugin version 0.1.1.12 and earlier all the settings above are available in **System > Configuration > Styla Connect**  as there is only one magazine available per store view. 
+
 
 ## StylaApiAdminUser and StylaApi2Role - please don't modify
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,4 +1,6 @@
 # Configuration
+
+In order to set up connection between your Magento and Styla, please do the following:
 * Login into your magento backend
 * Navigate to "System -> Configuration" and open the section "Styla Connect"
 * Please use the "Configuration Assistant" to connect your store with Styla. The assistant will automatically configure the required `RestApi` user and will take care of the authorization process: 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -79,7 +79,7 @@ Styla plugin version 0.2.0.0 introduced a possibility to set up several magazine
 </table>
 
 
-### CMS > Styla Magazines (for each magazine separately):
+### CMS > Styla Magazines (for each magazine separately, set up new magazines there):
 
 <table>
 <tr>
@@ -145,8 +145,6 @@ footer
 </table>
 
 /* - Please do not modify these values. This configuration will be automatically set during the “Styla Connect” process from the previous step.
-
-You can also add new magazines there.
 
 For Styla plugin version 0.1.1.12 and earlier all the settings above are available in **System > Configuration > Styla Connect**  as there is only one magazine available per store view. 
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -3,6 +3,7 @@
 * Copy the content of the zip file into your "Magento Root" directory
 * Change the folder permissions recursivly if needed
 * Clear the cache
+* Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information 
 * Start the [Configuration](configuration.md)
 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
-1. change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
-2. insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+&nbsp;-change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+&nbsp;-insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -4,7 +4,9 @@
 * Change the folder permissions recursivly if needed
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
-* Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information 
+* Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
+   * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+   * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
- * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
- * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+- change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+- insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
-⋅⋅* change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
-⋅⋅* insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+ * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+ * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
-- change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
-- insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+1. change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+2. insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+If you currently have version 0.1.1.11 or older installed, please first go throught the below for 0.1.1.12 and only then install 0.2.0.0 or later. There are changes in the plugin structure that potentially might cause issues when updating directly from pre-0.1.1.12 to 0.2.0.0 or later.
+
 * Copy the content of the zip file into your "Magento Root" directory
 * Change the folder permissions recursivly if needed
 * Clear the cache

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
-   * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
-   * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+⋅⋅* change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+⋅⋅* insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
- * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
- * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+   * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+   * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -5,8 +5,8 @@
 * Clear the cache
 * Make sure you relogin in magento admin if getting a 404 error during changing styla plugin settings
 * Make sure to activate [Magento REST API](http://devdocs.magento.com/guides/m1x/api/rest/introduction.html) to share product information with Styla. You have to configure the below in your .htaccess:
-&nbsp;-change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
-&nbsp;-insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
+ * change `Options +FollowSymLinks` to `Options +FollowSymLinks -MultiViews` 
+ * insert `RewriteRule ^api api.php?type=rest [QSA,L]` directly under `#RewriteBase /magento/`
 * Start the [Configuration](configuration.md)
 
 ### Please do not create any subpages in your CMS or directories for your magazine. The plugin itself will take care of setting up the /magazine/ (or any other) page on which the magazine will appear and of the routing as well. 


### PR DESCRIPTION
From magento CE 1.9.3 fulltext search is triggered in a new way. That's why method getAllIds() returns all products ids - collection is not filtered at all. Method getFoundIds() should be used instead.

PR consists additionally sorting collection by searching relevance.